### PR TITLE
Omit endpoint parameters marked with `x-hidden`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
             parser: '@typescript-eslint/parser',
             parserOptions: {
                 sourceType: 'module',
-                project: ['./tsconfig.test.json', './tsconfig.json'],
+                project: ['./src/__tests__/tsconfig.json', './tsconfig.json'],
                 tsconfigRootDir: __dirname,
             },
         },

--- a/src/@types/oasVendorExtensions.d.ts
+++ b/src/@types/oasVendorExtensions.d.ts
@@ -1,0 +1,13 @@
+import 'openapi-types';
+
+declare module 'openapi-types' {
+    namespace OpenAPIV3 {
+        interface BaseSchemaObject {
+            'x-hidden'?: boolean;
+        }
+
+        interface ParameterBaseObject {
+            'x-hidden'?: boolean;
+        }
+    }
+}

--- a/src/__snapshots__/hidden/endpointParameters.test.ts.snap
+++ b/src/__snapshots__/hidden/endpointParameters.test.ts.snap
@@ -1,0 +1,147 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Endpoint parameter tables should be omitted if all of their respective parameters are marked with \`x-hidden\` 1`] = `
+"<div class="openapi">
+
+# HiddenEndpointParameters
+
+## Request
+
+<div class="openapi__requests">
+
+<div class="openapi__request__wrapper" style="--method: var(--dc-openapi-methods-post);margin-bottom: 12px">
+
+<div class="openapi__request">
+
+POST {.openapi__method} 
+\`\`\`
+http://localhost:8080/test
+\`\`\`
+
+
+
+</div>
+
+Generated server url
+
+</div>
+
+</div>
+
+### Cookies
+
+#|||
+ **Name** 
+|
+ **Description** 
+||
+
+||
+ accessToken 
+|
+ **Type:** string
+
+Access token 
+|||#
+
+## Responses
+
+<div class="openapi__response__code__204">
+
+## 204 No Content
+
+<div class="openapi-entity">
+
+### Body
+
+{% cut "application/json" %}
+
+
+\`\`\`json
+{}
+\`\`\`
+
+
+{% endcut %}
+
+
+</div>
+
+</div>
+<!-- markdownlint-disable-file -->
+
+</div>"
+`;
+
+exports[`Endpoint parameter tables should not include parameters marked with \`x-hidden\` in the spec 1`] = `
+"<div class="openapi">
+
+# HiddenEndpointParameters
+
+## Request
+
+<div class="openapi__requests">
+
+<div class="openapi__request__wrapper" style="--method: var(--dc-openapi-methods-post);margin-bottom: 12px">
+
+<div class="openapi__request">
+
+POST {.openapi__method} 
+\`\`\`
+http://localhost:8080/test
+\`\`\`
+
+
+
+</div>
+
+Generated server url
+
+</div>
+
+</div>
+
+### Query parameters
+
+#|||
+ **Name** 
+|
+ **Description** 
+||
+
+||
+ name 
+|
+ **Type:** string
+
+Name for the requested star 
+|||#
+
+## Responses
+
+<div class="openapi__response__code__204">
+
+## 204 No Content
+
+<div class="openapi-entity">
+
+### Body
+
+{% cut "application/json" %}
+
+
+\`\`\`json
+{}
+\`\`\`
+
+
+{% endcut %}
+
+
+</div>
+
+</div>
+<!-- markdownlint-disable-file -->
+
+</div>"
+`;

--- a/src/__snapshots__/hidden/objectProps.test.ts.snap
+++ b/src/__snapshots__/hidden/objectProps.test.ts.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Properties in object schemas marked with \`x-hidden\` should not be rendered in the resulting markdown 1`] = `
+"<div class="openapi">
+
+# HiddenObjectProperties
+
+## Request
+
+<div class="openapi__requests">
+
+<div class="openapi__request__wrapper" style="--method: var(--dc-openapi-methods-post);margin-bottom: 12px">
+
+<div class="openapi__request">
+
+POST {.openapi__method} 
+\`\`\`
+http://localhost:8080/test
+\`\`\`
+
+
+
+</div>
+
+Generated server url
+
+</div>
+
+</div>
+
+<div class="openapi-entity">
+
+### Body
+
+{% cut "application/json" %}
+
+
+\`\`\`json
+{
+    "luminosityClass": "string",
+    "name": "string"
+}
+\`\`\`
+
+
+{% endcut %}
+
+
+#|||
+ **Name** 
+|
+ **Description** 
+||
+
+||
+ luminosityClass 
+|
+ **Type:** string
+
+Morgan-Keenan luminosity class for this star
+ 
+||
+
+||
+ name 
+|
+ **Type:** string
+
+Name of this star
+ 
+|||#
+
+</div>
+
+## Responses
+
+<div class="openapi__response__code__204">
+
+## 204 No Content
+
+<div class="openapi-entity">
+
+### Body
+
+{% cut "application/json" %}
+
+
+\`\`\`json
+{}
+\`\`\`
+
+
+{% endcut %}
+
+
+</div>
+
+</div>
+<!-- markdownlint-disable-file -->
+
+</div>"
+`;

--- a/src/__tests__/hidden/endpointParameters.test.ts
+++ b/src/__tests__/hidden/endpointParameters.test.ts
@@ -1,0 +1,94 @@
+import {DocumentBuilder, run} from '../__helpers__/run';
+
+const mockDocumentName = 'HiddenEndpointParameters';
+
+describe('Endpoint parameter tables', () => {
+    it('should not include parameters marked with `x-hidden` in the spec', async () => {
+        const spec = new DocumentBuilder(mockDocumentName)
+            .parameter({
+                in: 'query',
+                name: 'name',
+                description: 'Name for the requested star',
+                schema: {
+                    type: 'string',
+                },
+            })
+            .parameter({
+                in: 'query',
+                name: 'id',
+                description: 'Internal ID for the requested star',
+                schema: {
+                    type: 'string',
+                    format: 'uuid',
+                },
+                'x-hidden': true,
+            })
+            .parameter({
+                in: 'query',
+                name: 'catalogueCCDM',
+                description: 'CCDM designation for the requested star',
+                schema: {
+                    type: 'string',
+                },
+                'x-hidden': true,
+            })
+            .response(204, {})
+            .build();
+
+        const fs = await run(spec);
+
+        const page = fs.match(mockDocumentName);
+
+        expect(page).toMatchSnapshot();
+    });
+
+    it('should be omitted if all of their respective parameters are marked with `x-hidden`', async () => {
+        const spec = new DocumentBuilder(mockDocumentName)
+            .parameter({
+                in: 'query',
+                name: 'name',
+                description: 'Name for the requested star',
+                schema: {
+                    type: 'string',
+                },
+                'x-hidden': true,
+            })
+            .parameter({
+                in: 'query',
+                name: 'id',
+                description: 'Internal ID for the requested star',
+                schema: {
+                    type: 'string',
+                    format: 'uuid',
+                },
+                'x-hidden': true,
+            })
+            .parameter({
+                in: 'query',
+                name: 'catalogueCCDM',
+                description: 'CCDM designation for the requested star',
+                schema: {
+                    type: 'string',
+                },
+                'x-hidden': true,
+            })
+            // "Query parameters" table should not be rendered; however, not all cookie params are optional
+            // so we expect this one to be rendered.
+            .parameter({
+                in: 'cookie',
+                name: 'accessToken',
+                description: 'Access token',
+                schema: {
+                    type: 'string',
+                },
+            })
+            .response(204, {})
+            .build();
+
+        const fs = await run(spec);
+
+        const page = fs.match(mockDocumentName);
+
+        expect(page).toMatchSnapshot();
+    });
+});

--- a/src/__tests__/hidden/objectProps.test.ts
+++ b/src/__tests__/hidden/objectProps.test.ts
@@ -1,0 +1,44 @@
+import {DocumentBuilder, run} from '../__helpers__/run';
+
+const mockDocumentName = 'HiddenObjectProperties';
+
+describe('Properties in object schemas marked with `x-hidden`', () => {
+    it('should not be rendered in the resulting markdown', async () => {
+        const spec = new DocumentBuilder(mockDocumentName)
+            .component('StarDto', {
+                type: 'object',
+                properties: {
+                    id: {
+                        description: 'Internal ID for this star',
+                        type: 'string',
+                        format: 'uuid',
+                        'x-hidden': true,
+                    },
+                    luminosityClass: {
+                        description: 'Morgan-Keenan luminosity class for this star',
+                        type: 'string',
+                    },
+                    name: {
+                        description: 'Name of this star',
+                        type: 'string',
+                    },
+                    catalogueDesignationCCDM: {
+                        description: 'CCDM catalogue designation for this star',
+                        type: 'string',
+                        'x-hidden': true,
+                    },
+                },
+            })
+            .request({
+                schema: DocumentBuilder.ref('StarDto'),
+            })
+            .response(204, {})
+            .build();
+
+        const fs = await run(spec);
+
+        const page = fs.match(mockDocumentName);
+
+        expect(page).toMatchSnapshot();
+    });
+});

--- a/src/__tests__/tsconfig.json
+++ b/src/__tests__/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": [".", "../@types"],
+    "exclude": []
+}

--- a/src/includer/models.ts
+++ b/src/includer/models.ts
@@ -220,6 +220,9 @@ export type Parameter = {
     example?: Primitive;
     default?: Primitive;
     schema: OpenJSONSchema;
+
+    // vendor extensions
+    'x-hidden'?: boolean;
 };
 
 export type Responses = Response[];

--- a/src/includer/ui/endpoint.ts
+++ b/src/includer/ui/endpoint.ts
@@ -52,7 +52,7 @@ import {
     tabs,
     title,
 } from './common';
-import {getOrderedPropList} from './presentationUtils/orderedProps/getOrderedPropList';
+import {prepareRenderableParameterList} from './presentationUtils/prepareRenderableParameterList';
 
 function endpoint(data: Endpoint, sandboxPlugin: {host?: string; tabName?: string} | undefined) {
     // try to remember, which tables we are already printed on page
@@ -198,19 +198,13 @@ function parameters(pagePrintedRefs: Set<string>, params?: Parameters) {
                     partitionedParameters[parameterSource as In] ?? [],
                 ] as const,
         )
+        .map(
+            ([parameterSource, parameterList]) =>
+                [parameterSource, prepareRenderableParameterList(parameterList)] as const,
+        )
         .filter(([, parameterList]) => parameterList.length)
         .reduce<string[]>((contentAccumulator, [parameterSource, parameterList]) => {
-            const wellOrderedParameters = getOrderedPropList({
-                propList: parameterList,
-                iteratee: ({name, required}) => ({
-                    name,
-                    // required can actually be `undefined` in runtime
-                    isRequired: Boolean(required),
-                }),
-            });
-
-            const {contentRows, additionalRefs} =
-                getParameterSourceTableContents(wellOrderedParameters);
+            const {contentRows, additionalRefs} = getParameterSourceTableContents(parameterList);
 
             const tableHeading = sections[parameterSource];
 

--- a/src/includer/ui/presentationUtils/prepareRenderableParameterList.ts
+++ b/src/includer/ui/presentationUtils/prepareRenderableParameterList.ts
@@ -1,0 +1,27 @@
+import {Parameter} from '../../models';
+import {getOrderedPropList} from './orderedProps/getOrderedPropList';
+
+const shouldRenderParameter = (parameter: Parameter) => !parameter['x-hidden'];
+
+/**
+ * Get ordered & filtered parameter list, mostly ready for table rendering.
+ * Excludes parameters that should be hidden, applies lexicographic sort & hoists required ones to the top
+ * of the list.
+ * @param {ReadonlyArray<Parameter>} rawParamsFromSingleSource Raw parameter list of a single parameter source
+ * (path, query, etc.)
+ * @returns {ReadonlyArray<Parameter>} Well-ordered parameter list with hidden ones filtered out.
+ */
+export const prepareRenderableParameterList = (
+    rawParamsFromSingleSource: readonly Parameter[],
+): readonly Parameter[] => {
+    const filteredParams = rawParamsFromSingleSource.filter(shouldRenderParameter);
+
+    return getOrderedPropList({
+        propList: filteredParams,
+        iteratee: ({name, required}) => ({
+            name,
+            // required can actually be `undefined` in runtime
+            isRequired: Boolean(required),
+        }),
+    });
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "declaration": true
   },
   "include": ["src"],
-  "exclude": ["src/__tests__"],
   "ts-node": {
     "esm": true,
     "transpileOnly": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,11 @@
   "compilerOptions": {
     "target": "ES6",
     "jsx": "react",
-    "declaration": true
+    "declaration": true,
+    "baseUrl": "."
   },
   "include": ["src"],
+  "exclude": ["src/__tests__"],
   "ts-node": {
     "esm": true,
     "transpileOnly": true

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "include": ["src/__tests__", "src/@types"],
-    "exclude": []
-}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,5 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/__tests__"],
+    "include": ["src/__tests__", "src/@types"],
     "exclude": []
 }


### PR DESCRIPTION
Main changes:

- Endpoint parameters marked with `x-hidden` are now filtered out before rendering
- Parameter groups (query, path, cookie, etc.) are now omitted if all of their respective params are marked as hidden

Additional comments:

- We did not previously have tests for hidden props on object schemas — I added a test suite. I also believe it is possible to have an empty table rendered for a `component` if all of its `properties` are marked as hidden, but I didn't fix this behaviour yet.