### PR TITLE
Restore functionality to display default values for endpoint params

### DIFF
--- a/src/__snapshots__/basic.test.ts.snap
+++ b/src/__snapshots__/basic.test.ts.snap
@@ -63,19 +63,13 @@ Base 200 response
 ||
  foo 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -115,19 +109,13 @@ Base 200 response
 ||
  bar 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>

--- a/src/__snapshots__/combiners/allOf.test.ts.snap
+++ b/src/__snapshots__/combiners/allOf.test.ts.snap
@@ -56,28 +56,19 @@ Generated server url
 ||
  foo 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  name 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -117,10 +108,7 @@ Base 200 response
 ||
  baz 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
@@ -134,10 +122,7 @@ Base 200 response
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -207,8 +192,7 @@ Generated server url
 |
  **Type:** [Cat](#cat)
 
-Cat class
- 
+Cat class 
 |||#
 
 </div>
@@ -228,19 +212,13 @@ Cat class
 ||
  foo 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -284,8 +262,7 @@ Base 200 response
 |
  **Type:** [Cat](#cat)
 
-Cat class
- 
+Cat class 
 |||#
 
 </div>

--- a/src/__snapshots__/combiners/complex.test.ts.snap
+++ b/src/__snapshots__/combiners/complex.test.ts.snap
@@ -59,10 +59,7 @@ Generated server url
 ||
  age 
 |
- **Type:** any
-
-
- 
+ **Type:** any 
 ||
 
 ||
@@ -106,19 +103,13 @@ Dog class
 ||
  bar 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -138,19 +129,13 @@ Cat class
 ||
  foo 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -194,10 +179,7 @@ Base 200 response
 ||
  age 
 |
- **Type:** any
-
-
- 
+ **Type:** any 
 ||
 
 ||

--- a/src/__snapshots__/combiners/oneOf.test.ts.snap
+++ b/src/__snapshots__/combiners/oneOf.test.ts.snap
@@ -85,19 +85,13 @@ Dog class
 ||
  baz 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -117,19 +111,13 @@ Cat class
 ||
  foo 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -245,19 +233,13 @@ Generated server url
 ||
  age 
 |
- **Type:** number
-
-
- 
+ **Type:** number 
 ||
 
 ||
  name 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
@@ -293,19 +275,13 @@ Dog class
 ||
  baz 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -325,19 +301,13 @@ Cat class
 ||
  foo 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -377,19 +347,13 @@ Cat class
 ||
  age 
 |
- **Type:** number
-
-
- 
+ **Type:** number 
 ||
 
 ||
  name 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
@@ -476,10 +440,7 @@ Generated server url
  pet 
 |
  **Type:** [Dog](#dog) 
-or [Cat](#cat)
-
-
- 
+or [Cat](#cat) 
 ||
 
 ||
@@ -515,19 +476,13 @@ Dog class
 ||
  baz 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -547,19 +502,13 @@ Cat class
 ||
  foo 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -602,10 +551,7 @@ Cat class
  pet 
 |
  **Type:** [Dog](#dog) 
-or [Cat](#cat)
-
-
- 
+or [Cat](#cat) 
 ||
 
 ||

--- a/src/__snapshots__/constraints/default.test.ts.snap
+++ b/src/__snapshots__/constraints/default.test.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Property rows in tables describing object schemas are hoisted to the top of the table if marked as required by the spec 1`] = `
+exports[`Default value constraints should process default constraints specified for parameters 1`] = `
 "<div class="openapi">
 
-# ObjectPropertyOrder
+# DefaultValueConstraints
 
 ## Request
 
@@ -28,25 +28,7 @@ Generated server url
 
 </div>
 
-<div class="openapi-entity">
-
-### Body
-
-{% cut "application/json" %}
-
-
-\`\`\`json
-{
-    "id": "c3073b9d-edd0-49f2-a28d-b7ded8ff9a8b",
-    "luminosityClass": "string",
-    "name": "string",
-    "catalogueDesignationCCDM": "string"
-}
-\`\`\`
-
-
-{% endcut %}
-
+### Query parameters
 
 #|||
  **Name** 
@@ -55,38 +37,12 @@ Generated server url
 ||
 
 ||
- id<span class="openapi__required">*</span> 
+ limit 
 |
- **Type:** string&lt;uuid&gt;
+ **Type:** number&lt;int32&gt;
 
-Internal ID for this star 
-||
-
-||
- luminosityClass<span class="openapi__required">*</span> 
-|
- **Type:** string
-
-Morgan-Keenan luminosity class for this star 
-||
-
-||
- name<span class="openapi__required">*</span> 
-|
- **Type:** string
-
-Name of this star 
-||
-
-||
- catalogueDesignationCCDM 
-|
- **Type:** string
-
-CCDM catalogue designation for this star 
+Amount of search results to show<br><span class="openapi-description-annotation">Default:</span> \`10\` 
 |||#
-
-</div>
 
 ## Responses
 
@@ -117,10 +73,10 @@ CCDM catalogue designation for this star
 </div>"
 `;
 
-exports[`Property rows in tables describing object schemas are ordered lexicographically by default 1`] = `
+exports[`Default value constraints should process default constraints specified in schema objects 1`] = `
 "<div class="openapi">
 
-# ObjectPropertyOrder
+# DefaultValueConstraints
 
 ## Request
 
@@ -154,10 +110,12 @@ Generated server url
 
 \`\`\`json
 {
-    "id": "c3073b9d-edd0-49f2-a28d-b7ded8ff9a8b",
-    "luminosityClass": "string",
-    "name": "string",
-    "catalogueDesignationCCDM": "string"
+    "role": "basic",
+    "name": "Anonymous",
+    "tags": [
+        "blah"
+    ],
+    "age": 7
 }
 \`\`\`
 
@@ -172,27 +130,11 @@ Generated server url
 ||
 
 ||
- catalogueDesignationCCDM 
+ age 
 |
- **Type:** string
+ **Type:** number
 
-CCDM catalogue designation for this star 
-||
-
-||
- id 
-|
- **Type:** string&lt;uuid&gt;
-
-Internal ID for this star 
-||
-
-||
- luminosityClass 
-|
- **Type:** string
-
-Morgan-Keenan luminosity class for this star 
+<span class="openapi-description-annotation">Default:</span> \`7\` 
 ||
 
 ||
@@ -200,7 +142,23 @@ Morgan-Keenan luminosity class for this star
 |
  **Type:** string
 
-Name of this star 
+<span class="openapi-description-annotation">Default:</span> \`Anonymous\` 
+||
+
+||
+ role 
+|
+ **Type:** string
+
+Role for the user being created<br><span class="openapi-description-annotation">Default:</span> \`basic\`<br><span class="openapi-description-annotation">Enum:</span> \`basic\`, \`admin\` 
+||
+
+||
+ tags 
+|
+ **Type:** string[]
+
+<span class="openapi-description-annotation">Default:</span> \`blah\` 
 |||#
 
 </div>

--- a/src/__snapshots__/constraints/length.test.ts.snap
+++ b/src/__snapshots__/constraints/length.test.ts.snap
@@ -73,8 +73,7 @@ Generated server url
 |
  **Type:** [Cat](#cat)
 
-From response
- 
+From response 
 ||
 
 ||
@@ -82,8 +81,7 @@ From response
 |
  **Type:** [Cat](#cat)
 
-Cat class
- 
+Cat class 
 ||
 
 ||
@@ -91,8 +89,7 @@ Cat class
 |
  **Type:** [Dog](#dog)
 
-Dog class
- 
+Dog class 
 |||#
 
 </div>
@@ -120,10 +117,7 @@ Cat class
 ||
  name 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -153,8 +147,7 @@ Dog class
 |
  **Type:** string
 
-Pet name
-<br><span class="openapi-description-annotation">Max length:</span> \`100\` 
+Pet name<br><span class="openapi-description-annotation">Max length:</span> \`100\` 
 |||#
 
 </div>

--- a/src/__snapshots__/description.test.ts.snap
+++ b/src/__snapshots__/description.test.ts.snap
@@ -74,8 +74,7 @@ Generated server url
 |
  **Type:** [Cat](#cat)
 
-From response
- 
+From response 
 ||
 
 ||
@@ -83,8 +82,7 @@ From response
 |
  **Type:** [Cat](#cat)
 
-Cat class
- 
+Cat class 
 ||
 
 ||
@@ -92,8 +90,7 @@ Cat class
 |
  **Type:** [Dog](#dog)
 
-Dog class
- 
+Dog class 
 ||
 
 ||
@@ -101,8 +98,7 @@ Dog class
 |
  **Type:** object
 
-Simple description
- 
+Simple description 
 |||#
 
 </div>
@@ -122,19 +118,13 @@ Cat class
 ||
  foo 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -154,19 +144,13 @@ Dog class
 ||
  bar 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>

--- a/src/__snapshots__/examples/array.test.ts.snap
+++ b/src/__snapshots__/examples/array.test.ts.snap
@@ -59,11 +59,7 @@ Generated server url
 ||
  a 
 |
- **Type:** object[]
-
-
-
- 
+ **Type:** object[] 
 |||#
 
 </div>
@@ -160,11 +156,7 @@ Generated server url
 ||
  a 
 |
- **Type:** any[]
-
-
-
- 
+ **Type:** any[] 
 |||#
 
 </div>
@@ -258,11 +250,7 @@ Generated server url
  a 
 |
  **Type:** (string 
-or integer)[]
-
-
-
- 
+or integer)[] 
 |||#
 
 </div>
@@ -447,10 +435,7 @@ Generated server url
 ||
  name 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -552,10 +537,7 @@ Generated server url
 ||
  name 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>

--- a/src/__snapshots__/examples/base.test.ts.snap
+++ b/src/__snapshots__/examples/base.test.ts.snap
@@ -132,10 +132,7 @@ Generated server url
 ||
  name 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>
@@ -243,10 +240,7 @@ Generated server url
 ||
  name 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>

--- a/src/__snapshots__/hidden/objectProps.test.ts.snap
+++ b/src/__snapshots__/hidden/objectProps.test.ts.snap
@@ -57,8 +57,7 @@ Generated server url
 |
  **Type:** string
 
-Morgan-Keenan luminosity class for this star
- 
+Morgan-Keenan luminosity class for this star 
 ||
 
 ||
@@ -66,8 +65,7 @@ Morgan-Keenan luminosity class for this star
 |
  **Type:** string
 
-Name of this star
- 
+Name of this star 
 |||#
 
 </div>

--- a/src/__snapshots__/required.test.ts.snap
+++ b/src/__snapshots__/required.test.ts.snap
@@ -81,46 +81,31 @@ Generated server url
 ||
  a<span class="openapi__required">*</span> 
 |
- **Type:** number
-
-
- 
+ **Type:** number 
 ||
 
 ||
  b<span class="openapi__required">*</span> 
 |
- **Type:** number
-
-
- 
+ **Type:** number 
 ||
 
 ||
  d<span class="openapi__required">*</span> 
 |
- **Type:** number
-
-
- 
+ **Type:** number 
 ||
 
 ||
  c 
 |
- **Type:** number
-
-
- 
+ **Type:** number 
 ||
 
 ||
  e 
 |
- **Type:** number
-
-
- 
+ **Type:** number 
 |||#
 
 </div>
@@ -160,19 +145,13 @@ Cat class
 ||
  foo 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 ||
 
 ||
  type 
 |
- **Type:** string
-
-
- 
+ **Type:** string 
 |||#
 
 </div>

--- a/src/__tests__/constraints/default.test.ts
+++ b/src/__tests__/constraints/default.test.ts
@@ -1,0 +1,68 @@
+import {DocumentBuilder, run} from '../__helpers__/run';
+
+const mockDocumentName = 'DefaultValueConstraints';
+
+describe('Default value constraints', () => {
+    it('should process default constraints specified for parameters', async () => {
+        const spec = new DocumentBuilder(mockDocumentName)
+            .parameter({
+                in: 'query',
+                name: 'limit',
+                description: 'Amount of search results to show',
+                schema: {
+                    type: 'number',
+                    format: 'int32',
+                    default: 10,
+                },
+            })
+            .response(204, {})
+            .build();
+
+        const fs = await run(spec);
+
+        const page = fs.match(mockDocumentName);
+
+        expect(page).toMatchSnapshot();
+    });
+
+    it('should process default constraints specified in schema objects', async () => {
+        const spec = new DocumentBuilder(mockDocumentName)
+            .component('CreateUserRequestDto', {
+                type: 'object',
+                properties: {
+                    role: {
+                        description: 'Role for the user being created',
+                        type: 'string',
+                        enum: ['basic', 'admin'],
+                        default: 'basic',
+                    },
+                    name: {
+                        type: 'string',
+                        default: 'Anonymous',
+                    },
+                    tags: {
+                        type: 'array',
+                        items: {
+                            type: 'string',
+                            default: 'blah',
+                        },
+                    },
+                    age: {
+                        type: 'number',
+                        default: 7,
+                    },
+                },
+            })
+            .request({
+                schema: DocumentBuilder.ref('CreateUserRequestDto'),
+            })
+            .response(204, {})
+            .build();
+
+        const fs = await run(spec);
+
+        const page = fs.match(mockDocumentName);
+
+        expect(page).toMatchSnapshot();
+    });
+});

--- a/src/__tests__/constraints/length.test.ts
+++ b/src/__tests__/constraints/length.test.ts
@@ -1,4 +1,4 @@
-import {DocumentBuilder, run} from './__helpers__/run';
+import {DocumentBuilder, run} from '../__helpers__/run';
 
 const name = 'length';
 describe('length', () => {

--- a/src/includer/traverse/description.ts
+++ b/src/includer/traverse/description.ts
@@ -1,4 +1,3 @@
-import {EOL} from '../constants';
 import {OpenJSONSchema} from '../models';
 import {concatNewLine} from '../utils';
 
@@ -74,10 +73,8 @@ const fields: Fields = [
 ];
 
 function prepareComplexDescription(baseDescription: string, value: OpenJSONSchema): string {
-    const description = baseDescription + EOL;
-
     return fields.reduce((acc, curr) => {
-        const field = typeof curr === 'function' ? curr(value) : curr;
+        const field = typeof curr === 'function' ? curr(value) : curr; //?
 
         if (typeof field === 'undefined' || !value[field.key]) {
             return acc;
@@ -86,7 +83,7 @@ function prepareComplexDescription(baseDescription: string, value: OpenJSONSchem
         const {key, label, computed, notWrapValueIntoCode} = field;
 
         return concatConstraint(acc, computed || value[key], label + ':', notWrapValueIntoCode);
-    }, description);
+    }, baseDescription);
 }
 
 function concatConstraint(

--- a/src/includer/traverse/types.ts
+++ b/src/includer/traverse/types.ts
@@ -81,7 +81,7 @@ function extractRefFromType(type: JSONSchemaType): string | undefined {
     return type.ref;
 }
 
-function collectRefs(type: JSONSchemaType): string[] | undefined {
+function collectRefs(type: JSONSchemaType): string[] {
     const result: JSONSchemaType[] = [];
 
     if (isUnionType(type)) {
@@ -90,7 +90,9 @@ function collectRefs(type: JSONSchemaType): string[] | undefined {
         result.push(type);
     }
 
-    return result.map(extractRefFromType).filter(Boolean) as string[] | undefined;
+    return result
+        .map(extractRefFromType)
+        .filter((maybeRef): maybeRef is string => typeof maybeRef !== 'undefined');
 }
 
 function isUnionType(type: JSONSchemaType): type is JSONSchemaUnionType {

--- a/src/includer/ui/endpoint.ts
+++ b/src/includer/ui/endpoint.ts
@@ -223,7 +223,7 @@ function parameters(pagePrintedRefs: Set<string>, params?: Parameters) {
 function parameterRow(param: Parameter): {cells: string[]; ref?: TableRef[]} {
     const row = prepareTableRowData(param.schema, param.name);
     let description = param.description ?? '';
-    if (!row.ref && row.description.length) {
+    if (!row.ref?.length && row.description.length) {
         // if row.ref present, row.description will be printed in separate table
         description = concatNewLine(description, row.description);
     }


### PR DESCRIPTION
- Fixed a bug where auto-generated description (with constraint annotation) for endpoint parameters would not get rendered in the resulting markdown.
- Fixed a bug in constraint annotation concat procedure, where the generator would emit more line terminators than necessary.

Maybe we need some more tests here (should be done in another PR):
- for all constraints we support
- for constraint concatenation (since it was still buggy and produced more line terminators than it should)

Constraints implementation is still wacky at times, for example, having a Spec Object like this:

```yaml
schema:
  type: number
  default: 0
```

would not produce a readable annotation for default value, since `0` is falsy :)