### PR TITLE
Replace separators in paths for Windows users

### DIFF
--- a/build/includer.js
+++ b/build/includer.js
@@ -6,7 +6,7 @@ const IN_PATH = path.resolve('src', 'includer');
 const OUT_PATH = 'includer';
 const FORMATS = ['cjs', 'esm'];
 
-const tsFiles = glob.sync(`${IN_PATH}/**/*.ts`);
+const tsFiles = glob.sync(`${IN_PATH.replace(/\\/g, '/')}/**/*.ts`);
 
 const build = (files, format) => Promise.all(files.map((name) => {
     const newFilePath = path.resolve(OUT_PATH, format, name.substring(IN_PATH.length + 1));

--- a/build/includer.js
+++ b/build/includer.js
@@ -2,11 +2,11 @@ const glob = require('glob');
 const path = require('node:path');
 const esbuild = require('esbuild');
 
-const IN_PATH = path.resolve('src', 'includer');
+const IN_PATH = path.resolve('src', 'includer').replace(/\\/g, '/');
 const OUT_PATH = 'includer';
 const FORMATS = ['cjs', 'esm'];
 
-const tsFiles = glob.sync(`${IN_PATH.replace(/\\/g, '/')}/**/*.ts`);
+const tsFiles = glob.sync(`${IN_PATH}/**/*.ts`);
 
 const build = (files, format) => Promise.all(files.map((name) => {
     const newFilePath = path.resolve(OUT_PATH, format, name.substring(IN_PATH.length + 1));


### PR DESCRIPTION
Windows paths contain '\\' separator. Replace '\\' to '/' because includer.js doesn't work correctly with '\\' separator in path.