### PR TITLE
Ensure that schema merging does not permanently overwrite descriptions

### DIFF
--- a/src/includer/services/refs.ts
+++ b/src/includer/services/refs.ts
@@ -81,7 +81,7 @@ function merge(schema: OpenJSONSchemaDefinition, needToSaveRef = true): OpenJSON
     const combiners = value.oneOf || value.allOf || [];
 
     if (combiners.length === 0) {
-        return value;
+        return {...value};
     }
 
     if (needToSaveRef && combiners.length === 1) {


### PR DESCRIPTION
No additional test cases, because `merge` is already a blackbox that seems to need a significant re-write.
Fixed an issue where the same schema object would get its description overwritten when used more than once (with `allOf` and without).