### PR TITLE
fix: Fix complex descriptions (with constraints)

### DIFF
--- a/src/includer/traverse/description.ts
+++ b/src/includer/traverse/description.ts
@@ -39,10 +39,11 @@ const fields: Fields = [
         key: 'pattern',
         label: 'Pattern',
     },
-    {
+    (value) => ({
         key: 'uniqueItems',
         label: 'Unique items',
-    },
+        computed: String(value.uniqueItems),
+    }),
     (value) => {
         return {
             key: 'minimum',
@@ -75,7 +76,7 @@ function prepareComplexDescription(baseDescription: string, value: OpenJSONSchem
     return fields.reduce((acc, curr) => {
         const field = typeof curr === 'function' ? curr(value) : curr;
 
-        if (typeof field === 'undefined' || !value[field.key]) {
+        if (typeof field === 'undefined' || typeof value[field.key] === 'undefined') {
             return acc;
         }
 


### PR DESCRIPTION
Before:
<img width="680" alt="image" src="https://github.com/user-attachments/assets/9c304e90-2303-4f76-90a0-ddeb5215ed08">

After:
<img width="685" alt="image" src="https://github.com/user-attachments/assets/7af94bfa-2876-46d0-8fc2-5c40eea2f482">


Using the `*${constraintLabel}*{.openapi-description-annotation}` construction at the end of a table cell results in the class being applied to the entire cell, there was also a hanging label, which is now understandable