### PR TITLE
fix: deprecated parameter name in table

### DIFF
--- a/src/__snapshots__/basic.test.ts.snap
+++ b/src/__snapshots__/basic.test.ts.snap
@@ -61,13 +61,13 @@ Base 200 response
 ||
 
 ||
- foo 
+ foo {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -107,13 +107,13 @@ Base 200 response
 ||
 
 ||
- bar 
+ bar {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#

--- a/src/__snapshots__/combiners/allOf.test.ts.snap
+++ b/src/__snapshots__/combiners/allOf.test.ts.snap
@@ -54,19 +54,19 @@ Generated server url
 ||
 
 ||
- foo 
+ foo {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -106,13 +106,13 @@ Base 200 response
 ||
 
 ||
- baz 
+ baz {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -123,7 +123,7 @@ Base 200 response
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -195,7 +195,7 @@ Generated server url
 ||
 
 ||
- pet 
+ pet {.openapi-table-parameter-name} 
 |
  **Type:** [Cat](#cat)
 
@@ -217,13 +217,13 @@ Cat class
 ||
 
 ||
- foo 
+ foo {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -265,7 +265,7 @@ Base 200 response
 ||
 
 ||
- pet 
+ pet {.openapi-table-parameter-name} 
 |
  **Type:** [Cat](#cat)
 

--- a/src/__snapshots__/combiners/complex.test.ts.snap
+++ b/src/__snapshots__/combiners/complex.test.ts.snap
@@ -57,13 +57,13 @@ Generated server url
 ||
 
 ||
- age 
+ age {.openapi-table-parameter-name} 
 |
  **Type:** any 
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -104,13 +104,13 @@ Dog class
 ||
 
 ||
- bar 
+ bar {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -130,13 +130,13 @@ Cat class
 ||
 
 ||
- foo 
+ foo {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -180,13 +180,13 @@ Base 200 response
 ||
 
 ||
- age 
+ age {.openapi-table-parameter-name} 
 |
  **Type:** any 
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string
 

--- a/src/__snapshots__/combiners/oneOf.test.ts.snap
+++ b/src/__snapshots__/combiners/oneOf.test.ts.snap
@@ -83,13 +83,13 @@ Dog class
 ||
 
 ||
- baz 
+ baz {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -109,13 +109,13 @@ Cat class
 ||
 
 ||
- foo 
+ foo {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -235,13 +235,13 @@ Generated server url
 ||
 
 ||
- age 
+ age {.openapi-table-parameter-name} 
 |
  **Type:** number 
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
@@ -277,13 +277,13 @@ Dog class
 ||
 
 ||
- baz 
+ baz {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -303,13 +303,13 @@ Cat class
 ||
 
 ||
- foo 
+ foo {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -349,13 +349,13 @@ Cat class
 ||
 
 ||
- age 
+ age {.openapi-table-parameter-name} 
 |
  **Type:** number 
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
@@ -445,7 +445,7 @@ Generated server url
 ||
 
 ||
- pet 
+ pet {.openapi-table-parameter-name} 
 |
  **Type:** [Dog](#dog) 
 or [Cat](#cat) 
@@ -482,13 +482,13 @@ Dog class
 ||
 
 ||
- baz 
+ baz {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -508,13 +508,13 @@ Cat class
 ||
 
 ||
- foo 
+ foo {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -556,7 +556,7 @@ Cat class
 ||
 
 ||
- pet 
+ pet {.openapi-table-parameter-name} 
 |
  **Type:** [Dog](#dog) 
 or [Cat](#cat) 

--- a/src/__snapshots__/constraints/default.test.ts.snap
+++ b/src/__snapshots__/constraints/default.test.ts.snap
@@ -37,7 +37,7 @@ Generated server url
 ||
 
 ||
- limit 
+ limit {.openapi-table-parameter-name} 
 |
  **Type:** number&lt;int32&gt;
 
@@ -137,7 +137,7 @@ Generated server url
 ||
 
 ||
- age 
+ age {.openapi-table-parameter-name} 
 |
  **Type:** number
 
@@ -148,7 +148,7 @@ Generated server url
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -159,7 +159,7 @@ Generated server url
 ||
 
 ||
- role 
+ role {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -172,7 +172,7 @@ Role for the user being created
 ||
 
 ||
- tags 
+ tags {.openapi-table-parameter-name} 
 |
  **Type:** string[]
 

--- a/src/__snapshots__/constraints/length.test.ts.snap
+++ b/src/__snapshots__/constraints/length.test.ts.snap
@@ -69,7 +69,7 @@ Generated server url
 ||
 
 ||
- pet 
+ pet {.openapi-table-parameter-name} 
 |
  **Type:** [Cat](#cat)
 
@@ -77,7 +77,7 @@ From response
 ||
 
 ||
- petWithoutDescription 
+ petWithoutDescription {.openapi-table-parameter-name} 
 |
  **Type:** [Cat](#cat)
 
@@ -85,7 +85,7 @@ Cat class
 ||
 
 ||
- refToSchemaWithDescription 
+ refToSchemaWithDescription {.openapi-table-parameter-name} 
 |
  **Type:** [Dog](#dog)
 
@@ -107,7 +107,7 @@ Cat class
 ||
 
 ||
- foo 
+ foo {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -118,7 +118,7 @@ Cat class
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -138,7 +138,7 @@ Dog class
 ||
 
 ||
- bar 
+ bar {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -151,7 +151,7 @@ Dog class
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string
 

--- a/src/__snapshots__/description.test.ts.snap
+++ b/src/__snapshots__/description.test.ts.snap
@@ -70,7 +70,7 @@ Generated server url
 ||
 
 ||
- pet 
+ pet {.openapi-table-parameter-name} 
 |
  **Type:** [Cat](#cat)
 
@@ -78,7 +78,7 @@ From response
 ||
 
 ||
- petWithoutDescription 
+ petWithoutDescription {.openapi-table-parameter-name} 
 |
  **Type:** [Cat](#cat)
 
@@ -86,7 +86,7 @@ Cat class
 ||
 
 ||
- refToSchemaWithDescription 
+ refToSchemaWithDescription {.openapi-table-parameter-name} 
 |
  **Type:** [Dog](#dog)
 
@@ -94,7 +94,7 @@ Dog class
 ||
 
 ||
- simpleDescription 
+ simpleDescription {.openapi-table-parameter-name} 
 |
  **Type:** object
 
@@ -116,13 +116,13 @@ Cat class
 ||
 
 ||
- foo 
+ foo {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -142,13 +142,13 @@ Dog class
 ||
 
 ||
- bar 
+ bar {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#

--- a/src/__snapshots__/examples/array.test.ts.snap
+++ b/src/__snapshots__/examples/array.test.ts.snap
@@ -57,7 +57,7 @@ Generated server url
 ||
 
 ||
- a 
+ a {.openapi-table-parameter-name} 
 |
  **Type:** object[] 
 |||#
@@ -158,7 +158,7 @@ Generated server url
 ||
 
 ||
- a 
+ a {.openapi-table-parameter-name} 
 |
  **Type:** any[] 
 |||#
@@ -255,7 +255,7 @@ Generated server url
 ||
 
 ||
- a 
+ a {.openapi-table-parameter-name} 
 |
  **Type:** (string 
 or integer)[] 
@@ -449,7 +449,7 @@ Generated server url
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -555,7 +555,7 @@ Generated server url
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#

--- a/src/__snapshots__/examples/base.test.ts.snap
+++ b/src/__snapshots__/examples/base.test.ts.snap
@@ -134,7 +134,7 @@ Generated server url
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#
@@ -246,7 +246,7 @@ Generated server url
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#

--- a/src/__snapshots__/hidden/endpointParameters.test.ts.snap
+++ b/src/__snapshots__/hidden/endpointParameters.test.ts.snap
@@ -37,7 +37,7 @@ Generated server url
 ||
 
 ||
- accessToken 
+ accessToken {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -114,7 +114,7 @@ Generated server url
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string
 

--- a/src/__snapshots__/hidden/objectProps.test.ts.snap
+++ b/src/__snapshots__/hidden/objectProps.test.ts.snap
@@ -53,7 +53,7 @@ Generated server url
 ||
 
 ||
- luminosityClass 
+ luminosityClass {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -61,7 +61,7 @@ Morgan-Keenan luminosity class for this star
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string
 

--- a/src/__snapshots__/objectPropertyOrder.test.ts.snap
+++ b/src/__snapshots__/objectPropertyOrder.test.ts.snap
@@ -55,7 +55,7 @@ Generated server url
 ||
 
 ||
- id<span class="openapi__required">*</span> 
+ id<span class="openapi__required">*</span> {.openapi-table-parameter-name} 
 |
  **Type:** string&lt;uuid&gt;
 
@@ -63,7 +63,7 @@ Internal ID for this star
 ||
 
 ||
- luminosityClass<span class="openapi__required">*</span> 
+ luminosityClass<span class="openapi__required">*</span> {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -71,7 +71,7 @@ Morgan-Keenan luminosity class for this star
 ||
 
 ||
- name<span class="openapi__required">*</span> 
+ name<span class="openapi__required">*</span> {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -79,7 +79,7 @@ Name of this star
 ||
 
 ||
- catalogueDesignationCCDM 
+ catalogueDesignationCCDM {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -176,7 +176,7 @@ Generated server url
 ||
 
 ||
- catalogueDesignationCCDM 
+ catalogueDesignationCCDM {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -184,7 +184,7 @@ CCDM catalogue designation for this star
 ||
 
 ||
- id 
+ id {.openapi-table-parameter-name} 
 |
  **Type:** string&lt;uuid&gt;
 
@@ -192,7 +192,7 @@ Internal ID for this star
 ||
 
 ||
- luminosityClass 
+ luminosityClass {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -200,7 +200,7 @@ Morgan-Keenan luminosity class for this star
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string
 

--- a/src/__snapshots__/parameterOrder.test.ts.snap
+++ b/src/__snapshots__/parameterOrder.test.ts.snap
@@ -37,7 +37,7 @@ Generated server url
 ||
 
 ||
- id<span class="openapi__required">*</span> 
+ id<span class="openapi__required">*</span> {.openapi-table-parameter-name} 
 |
  **Type:** string&lt;uuid&gt;
 
@@ -45,7 +45,7 @@ Internal ID for the requested star
 ||
 
 ||
- catalogueCCDM 
+ catalogueCCDM {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -53,7 +53,7 @@ CCDM designation for the requested star
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -130,7 +130,7 @@ Generated server url
 ||
 
 ||
- catalogueCCDM 
+ catalogueCCDM {.openapi-table-parameter-name} 
 |
  **Type:** string
 
@@ -138,7 +138,7 @@ CCDM designation for the requested star
 ||
 
 ||
- id 
+ id {.openapi-table-parameter-name} 
 |
  **Type:** string&lt;uuid&gt;
 
@@ -146,7 +146,7 @@ Internal ID for the requested star
 ||
 
 ||
- name 
+ name {.openapi-table-parameter-name} 
 |
  **Type:** string
 

--- a/src/__snapshots__/recursiveReferences.test.ts.snap
+++ b/src/__snapshots__/recursiveReferences.test.ts.snap
@@ -60,7 +60,7 @@ Generated server url
 ||
 
 ||
- A 
+ A {.openapi-table-parameter-name} 
 |
  **Type:** [RecurseMiddle](#recursemiddle) 
 |||#
@@ -78,7 +78,7 @@ Generated server url
 ||
 
 ||
- B 
+ B {.openapi-table-parameter-name} 
 |
  **Type:** [RecurseTop](#recursetop) 
 |||#
@@ -96,7 +96,7 @@ Generated server url
 ||
 
 ||
- A 
+ A {.openapi-table-parameter-name} 
 |
  **Type:** [RecurseMiddle](#recursemiddle) 
 |||#
@@ -171,7 +171,7 @@ Generated server url
 ||
 
 ||
- A 
+ A {.openapi-table-parameter-name} 
 |
  **Type:** [RecurseTop](#recursetop) 
 |||#
@@ -189,7 +189,7 @@ Generated server url
 ||
 
 ||
- A 
+ A {.openapi-table-parameter-name} 
 |
  **Type:** [RecurseTop](#recursetop) 
 |||#
@@ -264,7 +264,7 @@ Generated server url
 ||
 
 ||
- A 
+ A {.openapi-table-parameter-name} 
 |
  **Type:** [RecurseTop](#recursetop) 
 |||#
@@ -282,7 +282,7 @@ Generated server url
 ||
 
 ||
- A 
+ A {.openapi-table-parameter-name} 
 |
  **Type:** [RecurseTop](#recursetop) 
 |||#

--- a/src/__snapshots__/required.test.ts.snap
+++ b/src/__snapshots__/required.test.ts.snap
@@ -37,19 +37,19 @@ Generated server url
 ||
 
 ||
- c<span class="openapi__required">*</span> 
+ c<span class="openapi__required">*</span> {.openapi-table-parameter-name} 
 |
  **Type:** number 
 ||
 
 ||
- a 
+ a {.openapi-table-parameter-name} 
 |
  **Type:** number 
 ||
 
 ||
- b 
+ b {.openapi-table-parameter-name} 
 |
  **Type:** number 
 |||#
@@ -79,31 +79,31 @@ Generated server url
 ||
 
 ||
- a<span class="openapi__required">*</span> 
+ a<span class="openapi__required">*</span> {.openapi-table-parameter-name} 
 |
  **Type:** number 
 ||
 
 ||
- b<span class="openapi__required">*</span> 
+ b<span class="openapi__required">*</span> {.openapi-table-parameter-name} 
 |
  **Type:** number 
 ||
 
 ||
- d<span class="openapi__required">*</span> 
+ d<span class="openapi__required">*</span> {.openapi-table-parameter-name} 
 |
  **Type:** number 
 ||
 
 ||
- c 
+ c {.openapi-table-parameter-name} 
 |
  **Type:** number 
 ||
 
 ||
- e 
+ e {.openapi-table-parameter-name} 
 |
  **Type:** number 
 |||#
@@ -143,13 +143,13 @@ Cat class
 ||
 
 ||
- foo 
+ foo {.openapi-table-parameter-name} 
 |
  **Type:** string 
 ||
 
 ||
- type 
+ type {.openapi-table-parameter-name} 
 |
  **Type:** string 
 |||#

--- a/src/includer/ui/common.ts
+++ b/src/includer/ui/common.ts
@@ -133,7 +133,7 @@ function tableParameterName(key: string, {required, deprecated}: ParameterNamePr
         tableName += popups.deprecated({compact: true});
     }
 
-    return tableName;
+    return tableName + ' {.openapi-table-parameter-name}';
 }
 
 export {

--- a/src/runtime/index.scss
+++ b/src/runtime/index.scss
@@ -30,6 +30,10 @@
         display: inline-block;
     }
 
+    .openapi-table-parameter-name {
+        white-space: nowrap;
+    }
+
     & .openapi-deprecated {
         display: inline-block;
         background-color: var(--dc-openapi-deprecated-bg);


### PR DESCRIPTION
Before:
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/3ed9ee63-f715-4f91-985c-1595e0cc959b">

After:
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/de6121c6-a45e-4ec5-a7f9-592953a3a543">
