### PR TITLE
fix: change order constraints for consistency

### DIFF
--- a/src/includer/traverse/description.ts
+++ b/src/includer/traverse/description.ts
@@ -28,12 +28,12 @@ const fields: Fields = [
         label: 'Max length',
     },
     {
-        key: 'maxItems',
-        label: 'Max items',
-    },
-    {
         key: 'minItems',
         label: 'Min items',
+    },
+    {
+        key: 'maxItems',
+        label: 'Max items',
     },
     {
         key: 'pattern',


### PR DESCRIPTION
Before order:
Min length
Max length
Max items
Min items
<img width="873" alt="Снимок экрана 2024-11-06 в 12 59 33" src="https://github.com/user-attachments/assets/722236fb-5f10-4c2f-b058-cb19d5730e11">


After order:
Min length
Max length
Min items
Max items
<img width="874" alt="Снимок экрана 2024-11-06 в 13 06 55" src="https://github.com/user-attachments/assets/a2d55425-3b44-4223-8991-b802f3d9730e">
