### PR TITLE
chron: rename "params" to "parameters"

### DIFF
--- a/src/plugin/constants.ts
+++ b/src/plugin/constants.ts
@@ -4,9 +4,9 @@ import block from 'bem-cn-lite';
 export const Text = {
     BUTTON_SUBMIT: 'Send',
 
-    HEADER_PARAMS_SECTION_TITLE: 'Header params',
-    QUERY_PARAMS_SECTION_TITLE: 'Query params',
-    PATH_PARAMS_SECTION_TITLE: 'Path params',
+    HEADER_PARAMS_SECTION_TITLE: 'Header parameters',
+    QUERY_PARAMS_SECTION_TITLE: 'Query parameters',
+    PATH_PARAMS_SECTION_TITLE: 'Path parameters',
 
     BODY_INPUT_LABEL: 'Body',
 


### PR DESCRIPTION
This copy from info tab:
<img width="689" alt="Снимок экрана 2024-11-06 в 17 23 23" src="https://github.com/user-attachments/assets/6a200a1c-1444-46c7-9dde-99c9f5e79508">


<img width="585" alt="Снимок экрана 2024-11-06 в 17 24 02" src="https://github.com/user-attachments/assets/a289114e-c01a-4f16-9426-a2f40e88f422">
