### PR TITLE
fix: Made custom attribute "uniqueItems" without value

### DIFF
--- a/src/includer/traverse/description.ts
+++ b/src/includer/traverse/description.ts
@@ -103,9 +103,6 @@ function concatConstraint(
 }
 
 function prepareConstraintValue(value: unknown, notWrapValueIntoCode: boolean) {
-    if (typeof value === 'boolean') {
-        return '';
-    }
     return notWrapValueIntoCode ? value : `\`${value}\``;
 }
 

--- a/src/includer/traverse/description.ts
+++ b/src/includer/traverse/description.ts
@@ -82,6 +82,15 @@ function prepareComplexDescription(baseDescription: string, value: OpenJSONSchem
 
         const {key, label, computed, notWrapValueIntoCode} = field;
 
+        if (key === 'uniqueItems') {
+            return concatConstraint(
+                acc,
+                value[key] === true ? '&nbsp;' : computed,
+                label,
+                value[key] === true,
+            );
+        }
+
         return concatConstraint(acc, computed || value[key], label + ':', notWrapValueIntoCode);
     }, baseDescription);
 }


### PR DESCRIPTION
If an attribute in yaml needs to be displayed without a value, the entire cell will be grayed out. Replace empty value to &nbsp;