### PR TITLE
feat: add openapi companion DOCSTOOLS-5791

### DIFF
--- a/adr/ADR-003-openapi-companions.md
+++ b/adr/ADR-003-openapi-companions.md
@@ -1,0 +1,39 @@
+# ADR-003: OpenAPI companions — the extension's role
+
+This document is a short wrapper. The full end-to-end contract of the **OpenAPI companion**
+(`*.openapi.json`) feature is described in the canonical CLI ADR:
+`@diplodoc/cli` → `packages/cli/adr/ADR-007-openapi-companions.md`.
+
+## What the openapi-extension specifically does
+
+`src/includer`:
+
+- `companion.ts`:
+  - `buildCompanionDocument(document, spec)` — builds a standalone document from the partially
+    dereferenced input (schemas stay as `$ref`), keeping only the operations actually rendered,
+    stripping `x-hidden` and pruning unreachable `components.schemas`;
+  - `serializeCompanionDocument(document)` — minified JSON.
+- `index.ts` → `resolveCompanion()`:
+  - decides the effective `renderMode` (`inline` | `hidden` | `link`), including the automatic
+    `inline → link` switch driven by `maxOpenapiIncludeInlineSize` (default `100K`, cap `1M`,
+    `0` = always link) with an INFO log;
+  - decides whether the companion makes it into `files` (gating by `ai.openapiCompanions`,
+    `outputFormat`, `maxOpenapiIncludeSize`) — this is the single place emission is gated;
+  - degrades `link → inline` when the file cannot be created, to avoid dead links.
+- `utils.ts` → `companionFilename(input)` — derives the companion name from the source spec
+  (`petstore.yaml` -> `petstore.openapi.json`).
+- `ui/main.ts` — for `renderMode: link`, adds a link to the companion file on the leading page.
+- `constants.ts` / `models.ts` — `SPEC_RENDER_MODE_LINK`, the size limits,
+  `DEFAULT_OPENAPI_COMPANIONS_MODE` (the single default for `ai.openapiCompanions`), and the
+  `OpenApiBuildConfig` type (the slice of the build config the includer reads from `run.config`).
+
+Defaults for build config values come from the CLI (passed via `run.config`); the extension only
+applies its own fallbacks for standalone consumers that call the includer without a fully populated
+build config.
+
+Config (`ai.openapiCompanions`, `maxOpenapiIncludeInlineSize`), writing the file to disk, and the
+build manifest are the CLI's responsibility — see the canonical ADR.
+
+```
+
+```

--- a/src/__tests__/companion.renderMode.test.ts
+++ b/src/__tests__/companion.renderMode.test.ts
@@ -1,0 +1,149 @@
+import type {OpenApiBuildConfig, OpenApiIncluderParams, Run} from '../includer/models';
+
+import {describe, expect, it, vi} from 'vitest';
+import nodeFS from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+
+import {includer} from '../includer';
+
+import {DocumentBuilder} from './__helpers__/run';
+
+type IncludeResult = {
+    files: Map<string, string>;
+    infoLogs: string[];
+    /** Expected companion file name derived from the input spec name. */
+    companion: string;
+};
+
+async function include(
+    spec: string,
+    options: Partial<OpenApiIncluderParams> = {},
+    config?: OpenApiBuildConfig,
+): Promise<IncludeResult> {
+    const id = Math.ceil(Math.random() * 10000000);
+    const tempRoot = nodeFS.mkdtempSync(join(tmpdir(), 'openapi-companion-'));
+    const infoLogs: string[] = [];
+
+    const params = {input: `spec-${id}.yaml`, ...options};
+    const companion = params.input.replace(/\.[^.]+$/, '') + '.openapi.json';
+    const run = {
+        input: tempRoot,
+        config,
+        logger: {
+            info: (message: string) => infoLogs.push(message),
+            warn: vi.fn(),
+        },
+        read: async () => '',
+        vars: {for: vi.fn()},
+    } as unknown as Run;
+
+    nodeFS.writeFileSync(join(tempRoot, params.input), spec);
+
+    try {
+        const {files} = await includer(run, params, join(tempRoot, 'toc.yaml'));
+        const map = new Map(files.map(({path, content}) => [path, content]));
+
+        return {files: map, infoLogs, companion};
+    } finally {
+        nodeFS.rmSync(tempRoot, {recursive: true, force: true});
+    }
+}
+
+function spec(): string {
+    return new DocumentBuilder('test').response(200, {description: 'ok'}).build();
+}
+
+describe('OpenAPI companion render mode', () => {
+    it('derives the companion file name from the source spec name', async () => {
+        const {files, companion} = await include(spec(), {input: 'petstore.yaml'});
+
+        expect(companion).toBe('petstore.openapi.json');
+        expect(files.has('petstore.openapi.json')).toBe(true);
+        expect(files.has('index.openapi.json')).toBe(false);
+    });
+
+    it('emits the companion file and keeps inline spec for small specs by default', async () => {
+        const {files, companion} = await include(spec());
+
+        expect(files.has(companion)).toBe(true);
+        expect(files.get('index.md')).toContain('{% cut');
+        expect(files.get('index.md')).not.toContain(`(${companion})`);
+    });
+
+    it('renders a link to the companion when renderMode is "link"', async () => {
+        const {files, companion} = await include(spec(), {
+            leadingPage: {spec: {renderMode: 'link'}},
+        });
+
+        expect(files.has(companion)).toBe(true);
+        expect(files.get('index.md')).toContain(`(${companion})`);
+        expect(files.get('index.md')).not.toContain('{% cut');
+    });
+
+    it('does not render or emit the spec when renderMode is "hidden"', async () => {
+        const {files, companion} = await include(spec(), {
+            leadingPage: {spec: {renderMode: 'hidden'}},
+        });
+
+        expect(files.has(companion)).toBe(false);
+        expect(files.get('index.md')).not.toContain('{% cut');
+        expect(files.get('index.md')).not.toContain(`(${companion})`);
+    });
+
+    it('auto-switches inline -> link when the spec exceeds maxOpenapiIncludeInlineSize', async () => {
+        const {files, infoLogs, companion} = await include(spec(), undefined, {
+            content: {maxOpenapiIncludeInlineSize: 1},
+        });
+
+        expect(files.get('index.md')).toContain(`(${companion})`);
+        expect(files.get('index.md')).not.toContain('{% cut');
+        expect(infoLogs.some((line) => line.includes("changed from 'inline' to 'link'"))).toBe(
+            true,
+        );
+    });
+
+    it('always uses link mode when maxOpenapiIncludeInlineSize is 0', async () => {
+        const {files, companion} = await include(spec(), undefined, {
+            content: {maxOpenapiIncludeInlineSize: 0},
+        });
+
+        expect(files.get('index.md')).toContain(`(${companion})`);
+    });
+
+    it('does not emit the companion when ai.openapiCompanions is false', async () => {
+        const {files, companion} = await include(
+            spec(),
+            {leadingPage: {spec: {renderMode: 'link'}}},
+            {
+                ai: {openapiCompanions: false},
+            },
+        );
+
+        expect(files.has(companion)).toBe(false);
+        // Falls back to embedding to avoid a dead link.
+        expect(files.get('index.md')).toContain('{% cut');
+    });
+
+    it('emits the companion in md2html only when ai.openapiCompanions is true', async () => {
+        const onlyMd = await include(spec(), undefined, {
+            outputFormat: 'html',
+            ai: {openapiCompanions: 'md'},
+        });
+        expect(onlyMd.files.has(onlyMd.companion)).toBe(false);
+
+        const both = await include(spec(), undefined, {
+            outputFormat: 'html',
+            ai: {openapiCompanions: true},
+        });
+        expect(both.files.has(both.companion)).toBe(true);
+    });
+
+    it('does not emit the companion when it exceeds maxOpenapiIncludeSize', async () => {
+        const {files, companion} = await include(spec(), undefined, {
+            content: {maxOpenapiIncludeSize: 1},
+        });
+
+        expect(files.has(companion)).toBe(false);
+    });
+});

--- a/src/includer/companion.test.ts
+++ b/src/includer/companion.test.ts
@@ -1,0 +1,239 @@
+import type {OpenAPIV3} from 'openapi-types';
+import type {Specification, V3Endpoint, V3Tag} from './models';
+
+import {describe, expect, it} from 'vitest';
+
+import {buildCompanionDocument, serializeCompanionDocument, stripXHidden} from './companion';
+
+function endpoint(method: string, path: string): V3Endpoint {
+    return {
+        id: `${method}-${path}`,
+        method,
+        path: path.replace(/^\/+/, ''),
+        tags: [],
+        servers: [],
+        parameters: [],
+        responses: [],
+        security: [],
+    };
+}
+
+function spec(endpoints: V3Endpoint[], tags: Map<string, V3Tag> = new Map()): Specification {
+    return {tags, endpoints};
+}
+
+describe('stripXHidden', () => {
+    it('removes object properties whose value is marked x-hidden', () => {
+        const result = stripXHidden({
+            visible: {type: 'string'},
+            secret: {type: 'string', 'x-hidden': true},
+        });
+
+        expect(result).toEqual({visible: {type: 'string'}});
+    });
+
+    it('filters out hidden items from arrays (e.g. parameters)', () => {
+        const result = stripXHidden([{name: 'a'}, {name: 'b', 'x-hidden': true}, {name: 'c'}]);
+
+        expect(result).toEqual([{name: 'a'}, {name: 'c'}]);
+    });
+
+    it('strips the x-hidden annotation key itself', () => {
+        const result = stripXHidden({type: 'object', 'x-hidden': false});
+
+        expect(result).toEqual({type: 'object'});
+    });
+
+    it('recurses into nested structures', () => {
+        const result = stripXHidden({
+            schema: {
+                properties: {
+                    keep: {type: 'number'},
+                    drop: {type: 'number', 'x-hidden': true},
+                },
+            },
+        });
+
+        expect(result).toEqual({schema: {properties: {keep: {type: 'number'}}}});
+    });
+});
+
+describe('serializeCompanionDocument', () => {
+    it('produces minified JSON without insignificant whitespace', () => {
+        const json = serializeCompanionDocument({
+            openapi: '3.0.0',
+            info: {title: 't', version: '1'},
+            paths: {},
+        } as OpenAPIV3.Document);
+
+        expect(json).not.toMatch(/\n/);
+        expect(json).not.toMatch(/": /);
+        expect(JSON.parse(json)).toMatchObject({openapi: '3.0.0'});
+    });
+});
+
+describe('buildCompanionDocument', () => {
+    const baseDocument = (): OpenAPIV3.Document => ({
+        openapi: '3.0.0',
+        info: {title: 'T', version: '1'},
+        paths: {
+            '/a': {get: {responses: {'200': {description: 'ok'}}}},
+            '/b': {get: {responses: {'200': {description: 'ok'}}}},
+        },
+        components: {
+            schemas: {
+                Used: {type: 'object', properties: {id: {type: 'string'}}},
+                Unused: {type: 'object'},
+            },
+            securitySchemes: {
+                apiKey: {type: 'apiKey', name: 'key', in: 'header'},
+            },
+        },
+    });
+
+    it('keeps only the operations present in the specification', () => {
+        const document = baseDocument();
+        const result = buildCompanionDocument(document, spec([endpoint('get', '/a')]));
+
+        expect(Object.keys(result.paths)).toEqual(['/a']);
+        expect(result.paths['/b']).toBeUndefined();
+    });
+
+    it('prunes schemas that become unreachable', () => {
+        const document = baseDocument();
+        document.paths['/a'] = {
+            get: {
+                responses: {
+                    '200': {
+                        description: 'ok',
+                        content: {
+                            'application/json': {
+                                schema: {$ref: '#/components/schemas/Used'},
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = buildCompanionDocument(document, spec([endpoint('get', '/a')]));
+        const schemas = result.components?.schemas ?? {};
+
+        expect(schemas.Used).toBeDefined();
+        expect(schemas.Unused).toBeUndefined();
+    });
+
+    it('keeps non-schema component groups (e.g. securitySchemes) intact', () => {
+        const document = baseDocument();
+        const result = buildCompanionDocument(document, spec([endpoint('get', '/a')]));
+
+        expect(result.components?.securitySchemes?.apiKey).toBeDefined();
+    });
+
+    it('removes x-hidden fields from the emitted spec', () => {
+        const document = baseDocument();
+        document.components = {
+            ...document.components,
+            schemas: {
+                ...document.components?.schemas,
+                Used: {
+                    type: 'object',
+                    properties: {
+                        id: {type: 'string'},
+                        secret: {type: 'string', 'x-hidden': true} as OpenAPIV3.SchemaObject,
+                    },
+                },
+            },
+        };
+        document.paths['/a'] = {
+            get: {
+                responses: {
+                    '200': {
+                        description: 'ok',
+                        content: {
+                            'application/json': {schema: {$ref: '#/components/schemas/Used'}},
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = buildCompanionDocument(document, spec([endpoint('get', '/a')]));
+        const used = result.components?.schemas?.Used as OpenAPIV3.SchemaObject;
+
+        expect(used.properties?.id).toBeDefined();
+        expect(used.properties?.secret).toBeUndefined();
+        expect(serializeCompanionDocument(result)).not.toContain('x-hidden');
+    });
+
+    it('does not mutate the source paths object', () => {
+        const document = baseDocument();
+        buildCompanionDocument(document, spec([endpoint('get', '/a')]));
+
+        expect(Object.keys(document.paths)).toEqual(['/a', '/b']);
+    });
+});
+
+describe('buildCompanionDocument (OpenAPI 3.1.0)', () => {
+    // 3.1.0 specifics: `type` may be an array (e.g. nullable via `['string', 'null']`),
+    // `examples` is keyed, and JSON-Schema dialect keywords are allowed in schemas.
+    const document31 = (): OpenAPIV3.Document =>
+        ({
+            openapi: '3.1.0',
+            info: {title: 'T', version: '1', summary: 'short'},
+            paths: {
+                '/a': {
+                    get: {
+                        responses: {
+                            '200': {
+                                description: 'ok',
+                                content: {
+                                    'application/json': {
+                                        schema: {$ref: '#/components/schemas/Used'},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                '/b': {get: {responses: {'200': {description: 'ok'}}}},
+            },
+            components: {
+                schemas: {
+                    Used: {
+                        type: 'object',
+                        properties: {
+                            id: {type: ['string', 'null']},
+                            nested: {$ref: '#/components/schemas/Nested'},
+                            secret: {type: 'string', 'x-hidden': true},
+                        },
+                    },
+                    Nested: {type: 'object', properties: {ok: {type: 'boolean'}}},
+                    Unused: {type: 'object'},
+                },
+            },
+        }) as unknown as OpenAPIV3.Document;
+
+    it('preserves array-form `type` and transitive refs while pruning unused schemas', () => {
+        const result = buildCompanionDocument(document31(), spec([endpoint('get', '/a')]));
+        const schemas = result.components?.schemas ?? {};
+
+        expect(result.openapi).toBe('3.1.0');
+        expect(Object.keys(result.paths)).toEqual(['/a']);
+        expect(schemas.Used).toBeDefined();
+        expect(schemas.Nested).toBeDefined();
+        expect(schemas.Unused).toBeUndefined();
+
+        const used = schemas.Used as OpenAPIV3.SchemaObject;
+        expect((used.properties?.id as {type: unknown}).type).toEqual(['string', 'null']);
+    });
+
+    it('removes x-hidden fields from a 3.1.0 spec', () => {
+        const result = buildCompanionDocument(document31(), spec([endpoint('get', '/a')]));
+        const used = result.components?.schemas?.Used as OpenAPIV3.SchemaObject;
+
+        expect(used.properties?.id).toBeDefined();
+        expect(used.properties?.secret).toBeUndefined();
+        expect(serializeCompanionDocument(result)).not.toContain('x-hidden');
+    });
+});

--- a/src/includer/companion.ts
+++ b/src/includer/companion.ts
@@ -1,0 +1,230 @@
+import type {OpenAPIV3} from 'openapi-types';
+import type {Specification, V3Endpoint} from './models';
+
+import {ENDPOINT_METHODS} from './constants';
+import {trimSlashes} from './utils';
+
+/**
+ * Builds the standalone OpenAPI specification document that backs a generated section.
+ *
+ * The result is a valid OpenAPI document derived from the partially dereferenced input
+ * (schemas are kept as `$ref`s, so recursive schemas stay acyclic and serializable),
+ * narrowed down to exactly what the section actually exposes:
+ *  - only operations that survived the includer `filter` are kept (taken from {@link Specification});
+ *  - everything marked with `x-hidden: true` (parameters, schema properties, whole schemas) is removed;
+ *  - `components.schemas` that become unreachable after the above are pruned.
+ *
+ * It is intentionally derived from the processed document rather than the original source file,
+ * so a consumer cannot recover endpoints/fields that were deliberately filtered out.
+ */
+export function buildCompanionDocument(
+    document: OpenAPIV3.Document,
+    spec: Specification,
+): OpenAPIV3.Document {
+    const included = collectIncludedOperations(spec);
+    const withFilteredPaths = filterPaths(document, included);
+    const withoutHidden = stripXHidden(
+        withFilteredPaths as unknown as JsonValue,
+    ) as unknown as OpenAPIV3.Document;
+
+    return pruneSchemas(withoutHidden);
+}
+
+export function serializeCompanionDocument(document: OpenAPIV3.Document): string {
+    return JSON.stringify(document);
+}
+
+function operationKey(method: string, path: string): string {
+    return `${method.toLowerCase()} ${trimSlashes(path)}`;
+}
+
+function collectIncludedOperations(spec: Specification): Set<string> {
+    const keys = new Set<string>();
+
+    const addAll = (endpoints: V3Endpoint[]) => {
+        for (const endpoint of endpoints) {
+            keys.add(operationKey(endpoint.method, endpoint.path));
+        }
+    };
+
+    addAll(spec.endpoints);
+    spec.tags.forEach((tag) => addAll(tag.endpoints));
+
+    return keys;
+}
+
+/**
+ * Returns a deep copy of the document whose `paths` contain only the included operations.
+ * Path items that end up without any operation are dropped entirely.
+ */
+function filterPaths(document: OpenAPIV3.Document, included: Set<string>): OpenAPIV3.Document {
+    const clone = structuredClone(document);
+    const paths = clone.paths ?? {};
+    const nextPaths: OpenAPIV3.PathsObject = {};
+
+    for (const [path, pathItem] of Object.entries(paths)) {
+        if (!pathItem) {
+            continue;
+        }
+
+        let hasOperation = false;
+
+        for (const method of ENDPOINT_METHODS) {
+            const operation = (pathItem as OpenAPIV3.PathItemObject)[method];
+            if (!operation) {
+                continue;
+            }
+
+            if (included.has(operationKey(method, path))) {
+                hasOperation = true;
+            } else {
+                delete (pathItem as OpenAPIV3.PathItemObject)[method];
+            }
+        }
+
+        if (hasOperation) {
+            nextPaths[path] = pathItem;
+        }
+    }
+
+    clone.paths = nextPaths;
+
+    return clone;
+}
+
+type JsonObject = {[key: string]: JsonValue | undefined};
+type JsonValue = null | boolean | number | string | JsonValue[] | JsonObject;
+
+function isHidden(value: unknown): boolean {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        (value as {[key: string]: unknown})['x-hidden'] === true
+    );
+}
+
+/**
+ * Recursively removes everything annotated with `x-hidden: true`:
+ *  - array items that are hidden objects are filtered out (e.g. parameters);
+ *  - object entries whose value is a hidden object are deleted (e.g. schema properties);
+ *  - the `x-hidden` annotation itself is stripped from the output.
+ *
+ * Cycle-safe: already visited containers are returned as-is to avoid infinite recursion.
+ */
+export function stripXHidden(input: JsonValue, seen: WeakSet<object> = new WeakSet()): JsonValue {
+    if (Array.isArray(input)) {
+        if (seen.has(input)) {
+            return input;
+        }
+        seen.add(input);
+
+        return input.filter((item) => !isHidden(item)).map((item) => stripXHidden(item, seen));
+    }
+
+    if (typeof input === 'object' && input !== null) {
+        if (seen.has(input)) {
+            return input;
+        }
+        seen.add(input);
+
+        const result: JsonObject = {};
+
+        for (const [key, value] of Object.entries(input)) {
+            if (key === 'x-hidden') {
+                continue;
+            }
+            if (value === undefined || isHidden(value)) {
+                continue;
+            }
+            result[key] = stripXHidden(value, seen);
+        }
+
+        return result;
+    }
+
+    return input;
+}
+
+function collectRefs(input: JsonValue, refs: Set<string>, seen: WeakSet<object> = new WeakSet()) {
+    if (input === null || typeof input !== 'object') {
+        return;
+    }
+
+    if (seen.has(input)) {
+        return;
+    }
+    seen.add(input);
+
+    if (Array.isArray(input)) {
+        input.forEach((item) => collectRefs(item, refs, seen));
+        return;
+    }
+
+    for (const [key, value] of Object.entries(input)) {
+        if (key === '$ref' && typeof value === 'string') {
+            refs.add(value);
+        } else if (value !== undefined) {
+            collectRefs(value, refs, seen);
+        }
+    }
+}
+
+const SCHEMA_REF = /^#\/components\/schemas\/(.+)$/;
+
+/**
+ * Drops `components.schemas` entries that are not reachable from the rest of the document
+ * (transitively through `$ref`s). Other component groups (parameters, securitySchemes, ...)
+ * are left intact because they are not always referenced via `$ref` (e.g. security schemes
+ * are referenced by name).
+ */
+function pruneSchemas(document: OpenAPIV3.Document): OpenAPIV3.Document {
+    const components = document.components as
+        | {schemas?: {[name: string]: JsonValue}; [group: string]: unknown}
+        | undefined;
+    const schemas = components?.schemas;
+
+    if (!components || !schemas) {
+        return document;
+    }
+
+    // Roots: refs found everywhere except inside the schema definitions themselves.
+    const scanTarget: JsonValue = {
+        ...(document as unknown as JsonObject),
+        components: {...(components as unknown as JsonObject), schemas: undefined},
+    };
+    const roots = new Set<string>();
+    collectRefs(scanTarget, roots);
+
+    const reachable = new Set<string>();
+    const queue = [...roots];
+
+    while (queue.length) {
+        const ref = queue.pop() as string;
+        const match = SCHEMA_REF.exec(ref);
+        if (!match) {
+            continue;
+        }
+
+        const name = match[1];
+        if (reachable.has(name) || !(name in schemas)) {
+            continue;
+        }
+
+        reachable.add(name);
+
+        const childRefs = new Set<string>();
+        collectRefs(schemas[name], childRefs);
+        childRefs.forEach((childRef) => queue.push(childRef));
+    }
+
+    const nextSchemas: {[name: string]: JsonValue} = {};
+    for (const [name, value] of Object.entries(schemas)) {
+        if (reachable.has(name)) {
+            nextSchemas[name] = value;
+        }
+    }
+
+    (components as {schemas?: unknown}).schemas = nextSchemas;
+
+    return document;
+}

--- a/src/includer/constants.ts
+++ b/src/includer/constants.ts
@@ -29,12 +29,36 @@ export const SPEC_SECTION_TYPE = 'Open API';
 export const LEADING_PAGE_NAME_DEFAULT = 'Overview';
 export const SPEC_RENDER_MODE_HIDDEN = 'hidden';
 export const SPEC_RENDER_MODE_DEFAULT = 'inline';
+export const SPEC_RENDER_MODE_LINK = 'link';
 export const DEPRECATED_ANNOTATION = 'Deprecated';
 export const DEPRECATED_POPUP_TEXT =
     'No longer supported, please use an alternative and newer version.';
 export const SPEC_RENDER_MODES = new Set<string>([
     SPEC_RENDER_MODE_DEFAULT,
     SPEC_RENDER_MODE_HIDDEN,
+    SPEC_RENDER_MODE_LINK,
 ]);
 export const LEADING_PAGE_MODES = new Set<string>([LeadingPageMode.Leaf, LeadingPageMode.Section]);
 export const SYNTAX_HIGHLIGHT_LIMIT = 10000;
+
+/**
+ * Suffix of the standalone OpenAPI spec companion emitted next to the root leading page.
+ * The actual file name is derived from the includer input spec name
+ * (`petstore.yaml` -> `petstore.openapi.json`), see {@link companionFilename}.
+ */
+export const SPEC_COMPANION_SUFFIX = '.openapi.json';
+
+/** Link text used on the leading page when the spec is rendered as a `link`. */
+export const SPEC_LINK_TEXT = 'Open API specification';
+
+/**
+ * Single source of truth for the default `ai.openapiCompanions` mode.
+ * `'md'` -> emit the companion only in md2md builds.
+ */
+export const DEFAULT_OPENAPI_COMPANIONS_MODE = 'md' as const;
+
+/** Default `maxOpenapiIncludeInlineSize`: specs larger than this switch from `inline` to `link`. */
+export const DEFAULT_MAX_OPENAPI_INCLUDE_INLINE_SIZE = 100 * 1024; // 100 KiB
+
+/** Hard cap for `maxOpenapiIncludeInlineSize`: values above this are clamped down. */
+export const MAX_OPENAPI_INCLUDE_INLINE_SIZE_LIMIT = 1024 * 1024; // 1 MiB

--- a/src/includer/index.ts
+++ b/src/includer/index.ts
@@ -1,6 +1,7 @@
 import type {OpenAPIV3} from 'openapi-types';
 import type {
     Dereference,
+    LeadingPageSpecRenderMode,
     OpenApiIncluderParams,
     Run,
     Specification,
@@ -15,16 +16,22 @@ import {dirname, join} from 'path';
 import {readFileSync} from 'fs';
 import SwaggerParser from '@apidevtools/swagger-parser';
 
-import {filterUsefulContent, matchFilter, mdPath, sectionName} from './utils';
+import {companionFilename, filterUsefulContent, matchFilter, mdPath, sectionName} from './utils';
 import * as parsers from './parsers';
 import * as generators from './ui';
 import {$ref, RefsService} from './services/refs';
+import {buildCompanionDocument, serializeCompanionDocument} from './companion';
 import {
+    DEFAULT_MAX_OPENAPI_INCLUDE_INLINE_SIZE,
+    DEFAULT_OPENAPI_COMPANIONS_MODE,
     LEADING_PAGE_MODES,
     LEADING_PAGE_NAME_DEFAULT,
     LeadingPageMode,
+    MAX_OPENAPI_INCLUDE_INLINE_SIZE_LIMIT,
     SPEC_RENDER_MODES,
     SPEC_RENDER_MODE_DEFAULT,
+    SPEC_RENDER_MODE_HIDDEN,
+    SPEC_RENDER_MODE_LINK,
 } from './constants';
 
 class OpenApiIncluderError extends Error {
@@ -113,9 +120,13 @@ export async function includer(run: Run, params: OpenApiIncluderParams, tocPath:
         const spec = filterSpec(data, ctx);
         const info = parsers.info(data);
         const toc = generateToc(data, ctx);
+        const companionName = companionFilename(input);
+        const companion = resolveCompanion(data, spec, ctx, run, companionName);
+
         const files = [
-            generateMainPage(mergedData, spec, info, ctx),
+            generateMainPage(mergedData, spec, info, ctx, companion.renderMode, companionName),
             ...generateContent(spec, ctx),
+            companion.file,
         ].filter(Boolean) as {path: string; content: string}[];
 
         return {toc, files};
@@ -256,13 +267,12 @@ function generateMainPage(
     spec: Specification,
     info: V3Info,
     ctx: Context,
+    leadingPageSpecRenderMode: LeadingPageSpecRenderMode,
+    companionName: string,
 ) {
     const {params} = ctx;
-    const {input, leadingPage} = params;
+    const {input} = params;
     const customLeadingPageDir = dirname(ctx.relative(input));
-
-    const leadingPageSpecRenderMode = leadingPage?.spec?.renderMode ?? SPEC_RENDER_MODE_DEFAULT;
-    assertSpecRenderMode(leadingPageSpecRenderMode);
 
     const root = ctx.tag('__root__');
 
@@ -272,12 +282,115 @@ function generateMainPage(
 
     const mainContent = root?.path
         ? readFileSync(join(customLeadingPageDir, root.path)).toString()
-        : generators.main({data, info, spec, leadingPageSpecRenderMode}, ctx);
+        : generators.main(
+              {data, info, spec, leadingPageSpecRenderMode, companionFilename: companionName},
+              ctx,
+          );
 
     return {
         path: 'index.md',
         content: mainContent,
     };
+}
+
+type CompanionResult = {
+    renderMode: LeadingPageSpecRenderMode;
+    file?: {path: string; content: string};
+};
+
+/**
+ * Decides how the spec is exposed on the root leading page and whether the standalone
+ * `*.openapi.json` companion is emitted, taking into account:
+ *  - the configured `leadingPage.spec.renderMode`;
+ *  - `maxOpenapiIncludeInlineSize` (auto-switch `inline` -> `link` for large specs);
+ *  - `ai.openapiCompanions` and `outputFormat` (whether the file is produced at all);
+ *  - `maxOpenapiIncludeSize` (a too-large companion is not written).
+ *
+ * All of these knobs come from {@link Run.config} — i.e. they are passed in from the CLI
+ * build config (the single source where defaults are resolved). The fallbacks applied here
+ * ({@link DEFAULT_OPENAPI_COMPANIONS_MODE}, {@link resolveInlineLimit}) exist only for
+ * standalone includer consumers that call it without a fully-populated build config.
+ *
+ * This is the only place where companion emission is gated: the CLI extension simply writes
+ * whatever {@link CompanionResult.file} is returned, so there is no separate flag check there.
+ */
+function resolveCompanion(
+    data: Dereference<OpenAPIV3.Document>,
+    spec: Specification,
+    ctx: Context,
+    run: Run,
+    companionName: string,
+): CompanionResult {
+    const {params} = ctx;
+    const configured = params.leadingPage?.spec?.renderMode ?? SPEC_RENDER_MODE_DEFAULT;
+    assertSpecRenderMode(configured);
+
+    const root = ctx.tag('__root__');
+
+    // `hidden` never auto-changes and never emits a companion file.
+    if (configured === SPEC_RENDER_MODE_HIDDEN || root?.hidden) {
+        return {renderMode: SPEC_RENDER_MODE_HIDDEN};
+    }
+
+    const document = buildCompanionDocument(data as unknown as OpenAPIV3.Document, spec);
+    const content = serializeCompanionDocument(document);
+    const bytes = Buffer.byteLength(content, 'utf-8');
+
+    const config = run.config ?? {};
+    const willEmit = shouldEmitCompanion(config, bytes);
+    const inlineLimit = resolveInlineLimit(config.content?.maxOpenapiIncludeInlineSize);
+
+    let renderMode: LeadingPageSpecRenderMode = configured;
+    if (configured === SPEC_RENDER_MODE_DEFAULT && (inlineLimit === 0 || bytes > inlineLimit)) {
+        renderMode = SPEC_RENDER_MODE_LINK;
+    }
+
+    // Avoid a dead link: if no companion file will be written, fall back to embedding inline.
+    if (renderMode === SPEC_RENDER_MODE_LINK && !willEmit) {
+        renderMode = SPEC_RENDER_MODE_DEFAULT;
+    }
+
+    if (configured === SPEC_RENDER_MODE_DEFAULT && renderMode === SPEC_RENDER_MODE_LINK) {
+        run.logger?.info?.(
+            `OpenAPI leading page spec render mode changed from 'inline' to 'link': ` +
+                `specification size (${bytes} bytes) exceeds maxOpenapiIncludeInlineSize ` +
+                `(${inlineLimit} bytes).`,
+        );
+    }
+
+    return {
+        renderMode,
+        file: willEmit ? {path: companionName, content} : undefined,
+    };
+}
+
+function shouldEmitCompanion(config: NonNullable<Run['config']>, bytes: number): boolean {
+    const aiMode = config.ai?.openapiCompanions ?? DEFAULT_OPENAPI_COMPANIONS_MODE;
+    if (aiMode === false) {
+        return false;
+    }
+
+    // `'md'` -> only md2md; `true` -> both md2md and md2html.
+    const emitByOutputFormat = aiMode === true || config.outputFormat !== 'html';
+    if (!emitByOutputFormat) {
+        return false;
+    }
+
+    const maxFileSize = config.content?.maxOpenapiIncludeSize ?? 0;
+
+    return maxFileSize === 0 || bytes <= maxFileSize;
+}
+
+/** Resolves the effective inline-size limit: default when unset, clamped to the hard cap, 0 = always link. */
+function resolveInlineLimit(value?: number): number {
+    if (value === undefined) {
+        return DEFAULT_MAX_OPENAPI_INCLUDE_INLINE_SIZE;
+    }
+    if (value <= 0) {
+        return 0;
+    }
+
+    return Math.min(value, MAX_OPENAPI_INCLUDE_INLINE_SIZE_LIMIT);
 }
 
 /**

--- a/src/includer/models.ts
+++ b/src/includer/models.ts
@@ -4,6 +4,7 @@ import type {
     LeadingPageMode,
     SPEC_RENDER_MODE_DEFAULT,
     SPEC_RENDER_MODE_HIDDEN,
+    SPEC_RENDER_MODE_LINK,
 } from './constants';
 import type {V3Endpoint, V3Info, V3Response, V3Schema, V3Tag} from './parsers';
 
@@ -90,7 +91,8 @@ export type Primitive = string | number | boolean;
 
 export type LeadingPageSpecRenderMode =
     | typeof SPEC_RENDER_MODE_DEFAULT
-    | typeof SPEC_RENDER_MODE_HIDDEN;
+    | typeof SPEC_RENDER_MODE_HIDDEN
+    | typeof SPEC_RENDER_MODE_LINK;
 
 export type LeadingPageParams = {
     name?: string;
@@ -129,8 +131,26 @@ export type OpenApiIncluderParams = {
     };
 };
 
+export type OpenApiBuildConfig = {
+    outputFormat?: 'html' | 'md';
+    ai?: {
+        openapiCompanions?: boolean | 'md';
+    };
+    content?: {
+        /** If the companion JSON exceeds this size (bytes), the file is not created. 0 disables. */
+        maxOpenapiIncludeSize?: number;
+        /** If the spec exceeds this size (bytes), `inline` render mode auto-switches to `link`. */
+        maxOpenapiIncludeInlineSize?: number;
+    };
+};
+
 export type Run = {
     input: string;
+    config?: OpenApiBuildConfig;
+    logger?: {
+        info?(message: string): void;
+        warn?(message: string): void;
+    };
     vars: {
         for(path: string): YfmPreset;
     };

--- a/src/includer/parsers/paths.ts
+++ b/src/includer/parsers/paths.ts
@@ -5,6 +5,8 @@ import type {V3Tag} from './tags';
 import {getReasonPhrase} from 'http-status-codes';
 import slugify from 'slugify';
 
+import {trimSlashes} from '../utils';
+
 import {visitPaths} from './utils';
 
 export type V3Response = {
@@ -80,7 +82,7 @@ export function paths(
             summary,
             deprecated,
             description,
-            path: trimSlash(path),
+            path: trimSlashes(path),
             method,
             operationId,
             tags: tags.map((tag) => slugify(tag)),
@@ -126,7 +128,7 @@ function parseRequestBody(
 }
 
 function parseServer(server: OpenAPIV3.ServerObject): OpenAPIV3.ServerObject {
-    server.url = trimSlash(server.url);
+    server.url = trimSlashes(server.url);
 
     return server;
 }
@@ -157,8 +159,4 @@ function parseResponse([code, response]: [
     }
 
     return parsed;
-}
-
-function trimSlash(str: string) {
-    return str.replace(/^\/|\/$/g, '');
 }

--- a/src/includer/ui/main.ts
+++ b/src/includer/ui/main.ts
@@ -7,7 +7,9 @@ import {join} from 'path';
 import {
     CONTACTS_SECTION_NAME,
     ENDPOINTS_SECTION_NAME,
+    SPEC_LINK_TEXT,
     SPEC_RENDER_MODE_DEFAULT,
+    SPEC_RENDER_MODE_LINK,
     SPEC_SECTION_NAME,
     SPEC_SECTION_TYPE,
     TAGS_SECTION_NAME,
@@ -21,10 +23,12 @@ export type MainParams = {
     info: V3Info;
     spec: Specification;
     leadingPageSpecRenderMode: LeadingPageSpecRenderMode;
+    /** Companion file name used as the `link` target, e.g. `petstore.openapi.json`. */
+    companionFilename: string;
 };
 
 export function main(params: MainParams, ctx: Context) {
-    const {data, info, spec, leadingPageSpecRenderMode} = params;
+    const {data, info, spec, leadingPageSpecRenderMode, companionFilename} = params;
 
     return block([
         nolint(),
@@ -35,7 +39,7 @@ export function main(params: MainParams, ctx: Context) {
         info.description,
         contact(info.contact),
         sections(spec, ctx),
-        specification(data, leadingPageSpecRenderMode),
+        specification(data, leadingPageSpecRenderMode, companionFilename),
     ]);
 }
 
@@ -85,7 +89,15 @@ function sections({tags, endpoints}: Specification, ctx: Context) {
     return block(content);
 }
 
-function specification(data: unknown, renderMode: LeadingPageSpecRenderMode) {
+function specification(
+    data: unknown,
+    renderMode: LeadingPageSpecRenderMode,
+    companionFilename: string,
+) {
+    if (renderMode === SPEC_RENDER_MODE_LINK) {
+        return block([title(2)(SPEC_SECTION_NAME), link(SPEC_LINK_TEXT, companionFilename)]);
+    }
+
     return (
         renderMode === SPEC_RENDER_MODE_DEFAULT &&
         block([title(2)(SPEC_SECTION_NAME), cut(code(stringify(data, null, 4)), SPEC_SECTION_TYPE)])

--- a/src/includer/utils.test.ts
+++ b/src/includer/utils.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from 'vitest';
+
+import {companionFilename, trimSlashes} from './utils';
+
+describe('companionFilename', () => {
+    it('derives the name from a simple yaml spec', () => {
+        expect(companionFilename('petstore.yaml')).toBe('petstore.openapi.json');
+    });
+
+    it('uses only the base name, dropping the directory', () => {
+        expect(companionFilename('api/v1/petstore.yml')).toBe('petstore.openapi.json');
+    });
+
+    it('supports json source specs', () => {
+        expect(companionFilename('spec.json')).toBe('spec.openapi.json');
+    });
+
+    it('only strips the last extension for dotted names', () => {
+        expect(companionFilename('my.service.v2.yaml')).toBe('my.service.v2.openapi.json');
+    });
+});
+
+describe('trimSlashes', () => {
+    it('trims leading and trailing slashes', () => {
+        expect(trimSlashes('/pets/')).toBe('pets');
+    });
+
+    it('collapses repeated edge slashes', () => {
+        expect(trimSlashes('///pets///')).toBe('pets');
+    });
+
+    it('keeps inner slashes intact', () => {
+        expect(trimSlashes('/pets/{id}/')).toBe('pets/{id}');
+    });
+});

--- a/src/includer/utils.ts
+++ b/src/includer/utils.ts
@@ -1,6 +1,19 @@
 import type {OpenApiIncluderParams, Specification, V3Endpoint, V3Tag, YfmPreset} from './models';
 
+import {basename} from 'node:path';
 import {evaluate} from '@diplodoc/liquid';
+
+import {SPEC_COMPANION_SUFFIX} from './constants';
+
+export function trimSlashes(value: string): string {
+    return value.replace(/^\/+|\/+$/g, '');
+}
+
+export function companionFilename(input: string): string {
+    const base = basename(input).replace(/\.[^./\\]+$/, '');
+
+    return `${base}${SPEC_COMPANION_SUFFIX}`;
+}
 
 export function matchFilter(
     filter: OpenApiIncluderParams['filter'],


### PR DESCRIPTION
- new `renderMode: link` for `leadingPage.spec` — a link to
  `index.openapi.json` is added to the разводящая;
- auto-switching `inline → link` when exceeding `maxOpenapiIncludeInlineSize`
  (default 100K, cap 1M, 0 = always link) with INFO log;
- `buildCompanionDocument`: filtering by rendered operations, cleaning up `x-hidden`,
  cut-off of unreachable `components.schemas`, minified serialization;
- gating companion emission (`ai.openapiCompanions` / `outputFormat` / `maxOpenapiIncludeSize`)
  read from `run.config`.